### PR TITLE
🔀 :: 기기 알림 해제 시 인덱스 돌아오는 버그 #66

### DIFF
--- a/lib/screen/main_page.dart
+++ b/lib/screen/main_page.dart
@@ -125,7 +125,14 @@ class _MainPageState extends State<MainPage> {
                                             .applyResponseList![index * 2]
                                             .deviceId,
                                         isEnableNotification: false,
-                                        isWoman: false,
+                                        isWoman: snapshot
+                                                    .data!
+                                                    .applyResponseList![
+                                                        index * 2]
+                                                    .deviceId >
+                                                31
+                                            ? true
+                                            : false,
                                         machine: machine[snapshot
                                             .data!
                                             .applyResponseList![index * 2]

--- a/lib/service/receive_apply_list.dart
+++ b/lib/service/receive_apply_list.dart
@@ -11,7 +11,6 @@ void receiveApplyList(StreamController streamController) async {
   print('리스트 받아오기');
   socket.emit('view_request', deviceToken);
   socket.on('request_list', (data) {
-    print(data);
     streamController.sink.add(ApplyResponseList.fromJson(data));
   });
 }


### PR DESCRIPTION
알림 신청 리스트에서 알림 해제 시 위로 한칸 씩 밀릴때
왼쪽에도 여자 세탁실 인덱스 처리가 되도록 수정했습니다