### PR TITLE
🔀 :: 시작 페이지 우선순위 조정 #91

### DIFF
--- a/lib/screen/main_page.dart
+++ b/lib/screen/main_page.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:lotura/main.dart';
 import 'package:lotura/model/apply_response_list.dart';
-import 'package:lotura/model/osj_list.dart';
 import 'package:lotura/screen/setting_page.dart';
 import 'package:lotura/service/receive_apply_list.dart';
 import 'package:lotura/widget/osj_colors.dart';
@@ -11,9 +10,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:lotura/widget/machine_card.dart';
 
 class MainPage extends StatefulWidget {
-  const MainPage({super.key, required this.osjList});
-
-  final OsjList osjList;
+  const MainPage({super.key});
 
   @override
   State<MainPage> createState() => _MainPageState();

--- a/lib/screen/main_page.dart
+++ b/lib/screen/main_page.dart
@@ -10,15 +10,14 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:lotura/widget/machine_card.dart';
 
 class MainPage extends StatefulWidget {
-  const MainPage({super.key, required this.applyStreamController});
-
-  final StreamController<ApplyResponseList> applyStreamController;
+  const MainPage({super.key});
 
   @override
   State<MainPage> createState() => _MainPageState();
 }
 
 class _MainPageState extends State<MainPage> {
+  late StreamController<ApplyResponseList> applyStreamController;
   int selectedIndex = 0;
 
   final TextStyle bigStyle = TextStyle(
@@ -40,7 +39,8 @@ class _MainPageState extends State<MainPage> {
   @override
   void initState() {
     super.initState();
-    receiveApplyList(widget.applyStreamController);
+    applyStreamController = StreamController<ApplyResponseList>();
+    receiveApplyList(applyStreamController);
   }
 
   @override
@@ -99,7 +99,7 @@ class _MainPageState extends State<MainPage> {
             SizedBox(height: 20.0.h),
             Expanded(
               child: StreamBuilder(
-                  stream: widget.applyStreamController.stream,
+                  stream: applyStreamController.stream,
                   builder: (context, snapshot) {
                     if (snapshot.hasData) {
                       return ScrollConfiguration(
@@ -121,7 +121,7 @@ class _MainPageState extends State<MainPage> {
                                     children: [
                                       MachineCard(
                                           streamController:
-                                              widget.applyStreamController,
+                                              applyStreamController,
                                           index: snapshot
                                               .data!
                                               .applyResponseList![index * 2]
@@ -145,7 +145,7 @@ class _MainPageState extends State<MainPage> {
                                                   .length
                                           ? MachineCard(
                                               streamController:
-                                                  widget.applyStreamController,
+                                                  applyStreamController,
                                               index: snapshot
                                                   .data!
                                                   .applyResponseList![

--- a/lib/screen/main_page.dart
+++ b/lib/screen/main_page.dart
@@ -10,7 +10,9 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:lotura/widget/machine_card.dart';
 
 class MainPage extends StatefulWidget {
-  const MainPage({super.key});
+  const MainPage({super.key, required this.applyStreamController});
+
+  final StreamController<ApplyResponseList> applyStreamController;
 
   @override
   State<MainPage> createState() => _MainPageState();
@@ -18,30 +20,28 @@ class MainPage extends StatefulWidget {
 
 class _MainPageState extends State<MainPage> {
   int selectedIndex = 0;
-  late StreamController<ApplyResponseList> applyResponseController;
 
-  @override
-  void initState() {
-    super.initState();
-    applyResponseController = StreamController<ApplyResponseList>();
-    receiveApplyList(applyResponseController);
-  }
-
-  TextStyle bigStyle = TextStyle(
+  final TextStyle bigStyle = TextStyle(
     fontSize: 40.0.sp,
     color: OSJColors.black,
     fontWeight: FontWeight.bold,
   );
 
-  TextStyle smallStyle = TextStyle(
+  final TextStyle smallStyle = TextStyle(
     fontSize: 16.0.sp,
     color: OSJColors.gray500,
   );
 
-  Map machine = <String, Machine>{
+  final Map machine = <String, Machine>{
     "WASH": Machine.WASH,
     "DRY": Machine.DRY,
   };
+
+  @override
+  void initState() {
+    super.initState();
+    receiveApplyList(widget.applyStreamController);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -99,7 +99,7 @@ class _MainPageState extends State<MainPage> {
             SizedBox(height: 20.0.h),
             Expanded(
               child: StreamBuilder(
-                  stream: applyResponseController.stream,
+                  stream: widget.applyStreamController.stream,
                   builder: (context, snapshot) {
                     if (snapshot.hasData) {
                       return ScrollConfiguration(
@@ -121,7 +121,7 @@ class _MainPageState extends State<MainPage> {
                                     children: [
                                       MachineCard(
                                           streamController:
-                                              applyResponseController,
+                                              widget.applyStreamController,
                                           index: snapshot
                                               .data!
                                               .applyResponseList![index * 2]
@@ -145,7 +145,7 @@ class _MainPageState extends State<MainPage> {
                                                   .length
                                           ? MachineCard(
                                               streamController:
-                                                  applyResponseController,
+                                                  widget.applyStreamController,
                                               index: snapshot
                                                   .data!
                                                   .applyResponseList![

--- a/lib/screen/splash_page.dart
+++ b/lib/screen/splash_page.dart
@@ -15,19 +15,19 @@ class SplashPage extends StatefulWidget {
 }
 
 class _SplashPageState extends State<SplashPage> {
-  late StreamController<OsjList> controller;
+  late StreamController<OsjList> osjStreamController;
 
   @override
   void initState() {
     super.initState();
-    controller = StreamController();
-    socketInit(controller);
+    osjStreamController = StreamController<OsjList>();
+    socketInit(osjStreamController);
     Future.delayed(const Duration(milliseconds: 1100)).then(
       (value) => Navigator.pushAndRemoveUntil(
           context,
           MaterialPageRoute(
             builder: (context) => BottomNavi(
-              osjStreamController: controller,
+              osjStreamController: osjStreamController,
             ),
           ),
           (route) => false),

--- a/lib/widget/bottom_navi.dart
+++ b/lib/widget/bottom_navi.dart
@@ -22,13 +22,14 @@ class _BottomNaviState extends State<BottomNavi>
     with SingleTickerProviderStateMixin {
   late TabController controller;
 
-  int selectedIndex = 0;
+  int selectedIndex = 1;
   bool isChange = false;
 
   @override
   void initState() {
     super.initState();
     controller = TabController(length: 2, vsync: this)
+      ..index = 1
       ..animation?.addListener(() {
         if (controller.offset >= 0.5 &&
             controller.offset < 1.0 &&
@@ -88,7 +89,7 @@ class _BottomNaviState extends State<BottomNavi>
               return TabBarView(
                 controller: controller,
                 children: [
-                  MainPage(osjList: snapshot.data!),
+                  const MainPage(),
                   LaundryRoomPage(osjList: snapshot.data!),
                 ],
               );


### PR DESCRIPTION
원래는 신청 여부에 따라서 인덱스를 지정하려고 했지만,
시작 페이지는 그렇다 쳐도 앱 자체에서 신청을 취소해도 화면이 이동합니다.
인덱스 지정이 신청 리스트가 비어있는지 여부로 판단하기 때문에 그냥 초기 인덱스를 1로 박았습니다;;