### PR TITLE
🔀 :: 로딩 속도 개선 #104

### DIFF
--- a/lib/presentation/splash_page/ui/view/splash_page.dart
+++ b/lib/presentation/splash_page/ui/view/splash_page.dart
@@ -23,10 +23,10 @@ class _SplashPageState extends State<SplashPage> {
   @override
   void initState() {
     super.initState();
+    context.read<OSJBloc>().add(GetOSJEvent());
+    context.read<ApplyBloc>().add(GetApplyListEvent());
     Future.delayed(const Duration(milliseconds: 1100)).then(
       (value) {
-        context.read<OSJBloc>().add(GetOSJEvent());
-        context.read<ApplyBloc>().add(GetApplyListEvent());
         Navigator.pushAndRemoveUntil(
             context,
             MaterialPageRoute(


### PR DESCRIPTION
딜레이가 끝난 후 요청하던 로직을 동시에 진행하도록 바꾸었습니다
원래 1.1초 딜레이 이후 0.3~4초정도 대기했었지만, 개선 이후 바로 데이터가 보여집니다