### PR TITLE
🔀 :: 알림신청 or 취소 시 서버요청 1회 줄이기 #220

### DIFF
--- a/lib/data/apply/data_source/remote/remote_apply_data_source.dart
+++ b/lib/data/apply/data_source/remote/remote_apply_data_source.dart
@@ -32,14 +32,11 @@ class RemoteApplyDataSource {
     }
   }
 
-  Future<List<ApplyEntity>> applyCancel(
+  Future<void> applyCancel(
       {required ApplyCancelRequest applyCancelRequest}) async {
     applyCancelRequest.token = await _getToken();
     final response = await http.post(Uri.parse("$baseurl/push_cancel"),
         body: applyCancelRequest.toJson());
     if (response.statusCode != 200) throw Exception(response.body);
-    return (jsonDecode(response.body) as List<dynamic>)
-        .map((i) => ApplyResponse.fromJson(i).toEntity())
-        .toList();
   }
 }

--- a/lib/data/apply/data_source/remote/remote_apply_data_source.dart
+++ b/lib/data/apply/data_source/remote/remote_apply_data_source.dart
@@ -26,7 +26,8 @@ class RemoteApplyDataSource {
       {required SendFCMInfoRequest sendFCMInfoRequest}) async {
     sendFCMInfoRequest.token = await _getToken();
     final response = await http.post(Uri.parse("$baseurl/push_request"),
-        body: sendFCMInfoRequest.toJson());
+        headers: {"Content-Type": "application/json"},
+        body: json.encode(sendFCMInfoRequest.toJson()));
     if (response.statusCode != 200 && response.statusCode != 304) {
       throw Exception(response.body);
     }
@@ -36,7 +37,8 @@ class RemoteApplyDataSource {
       {required ApplyCancelRequest applyCancelRequest}) async {
     applyCancelRequest.token = await _getToken();
     final response = await http.post(Uri.parse("$baseurl/push_cancel"),
-        body: applyCancelRequest.toJson());
+        headers: {"Content-Type": "application/json"},
+        body: json.encode(applyCancelRequest.toJson()));
     if (response.statusCode != 200) throw Exception(response.body);
   }
 }

--- a/lib/data/apply/dto/request/apply_cancel_request.dart
+++ b/lib/data/apply/dto/request/apply_cancel_request.dart
@@ -1,6 +1,6 @@
 class ApplyCancelRequest {
   String? token;
-  String deviceId;
+  int deviceId;
 
   ApplyCancelRequest({this.token, required this.deviceId});
 

--- a/lib/data/apply/dto/request/send_fcm_info_request.dart
+++ b/lib/data/apply/dto/request/send_fcm_info_request.dart
@@ -1,7 +1,7 @@
 class SendFCMInfoRequest {
   String? token;
-  String deviceId;
-  String expectState;
+  int deviceId;
+  int expectState;
 
   SendFCMInfoRequest(
       {this.token, required this.deviceId, required this.expectState});

--- a/lib/data/apply/repository/apply_repository_impl.dart
+++ b/lib/data/apply/repository/apply_repository_impl.dart
@@ -13,18 +13,16 @@ class ApplyRepositoryImpl implements ApplyRepository {
       : _remoteApplyDataSource = remoteApplyDataSource;
 
   @override
-  Future<List<ApplyEntity>> getApplyList() async =>
+  Future<List<ApplyEntity>> getApplyList() =>
       _remoteApplyDataSource.getApplyList();
 
   @override
-  Future<void> sendFCMInfo(
-          {required SendFCMInfoRequest sendFCMInfoRequest}) async =>
+  Future<void> sendFCMInfo({required SendFCMInfoRequest sendFCMInfoRequest}) =>
       _remoteApplyDataSource.sendFCMInfo(
           sendFCMInfoRequest: sendFCMInfoRequest);
 
   @override
-  Future<List<ApplyEntity>> applyCancel(
-          {required ApplyCancelRequest applyCancelRequest}) async =>
+  Future<void> applyCancel({required ApplyCancelRequest applyCancelRequest}) =>
       _remoteApplyDataSource.applyCancel(
           applyCancelRequest: applyCancelRequest);
 }

--- a/lib/domain/apply/repository/apply_repository.dart
+++ b/lib/domain/apply/repository/apply_repository.dart
@@ -9,6 +9,5 @@ abstract class ApplyRepository {
 
   Future<void> sendFCMInfo({required SendFCMInfoRequest sendFCMInfoRequest});
 
-  Future<List<ApplyEntity>> applyCancel(
-      {required ApplyCancelRequest applyCancelRequest});
+  Future<void> applyCancel({required ApplyCancelRequest applyCancelRequest});
 }

--- a/lib/domain/apply/use_case/apply_cancel_use_case.dart
+++ b/lib/domain/apply/use_case/apply_cancel_use_case.dart
@@ -1,5 +1,4 @@
 import 'package:lotura/data/apply/dto/request/apply_cancel_request.dart';
-import 'package:lotura/domain/apply/entity/apply_entity.dart';
 import 'package:lotura/domain/apply/repository/apply_repository.dart';
 
 class ApplyCancelUseCase {
@@ -8,7 +7,6 @@ class ApplyCancelUseCase {
   ApplyCancelUseCase({required ApplyRepository applyRepository})
       : _applyRepository = applyRepository;
 
-  Future<List<ApplyEntity>> execute(
-          {required ApplyCancelRequest applyCancelRequest}) =>
+  Future<void> execute({required ApplyCancelRequest applyCancelRequest}) =>
       _applyRepository.applyCancel(applyCancelRequest: applyCancelRequest);
 }

--- a/lib/domain/apply/use_case/send_fcm_info_use_case.dart
+++ b/lib/domain/apply/use_case/send_fcm_info_use_case.dart
@@ -1,5 +1,4 @@
 import 'package:lotura/data/apply/dto/request/send_fcm_info_request.dart';
-import 'package:lotura/domain/apply/entity/apply_entity.dart';
 import 'package:lotura/domain/apply/repository/apply_repository.dart';
 
 class SendFCMInfoUseCase {
@@ -8,9 +7,6 @@ class SendFCMInfoUseCase {
   SendFCMInfoUseCase({required ApplyRepository applyRepository})
       : _applyRepository = applyRepository;
 
-  Future<List<ApplyEntity>> execute(
-      {required SendFCMInfoRequest sendFCMInfoRequest}) async {
-    await _applyRepository.sendFCMInfo(sendFCMInfoRequest: sendFCMInfoRequest);
-    return _applyRepository.getApplyList();
-  }
+  Future<void> execute({required SendFCMInfoRequest sendFCMInfoRequest}) =>
+      _applyRepository.sendFCMInfo(sendFCMInfoRequest: sendFCMInfoRequest);
 }

--- a/lib/presentation/apply_page/bloc/apply_event.dart
+++ b/lib/presentation/apply_page/bloc/apply_event.dart
@@ -1,6 +1,5 @@
-import 'package:lotura/data/apply/dto/request/apply_cancel_request.dart';
 import 'package:lotura/data/apply/dto/request/get_apply_list_request.dart';
-import 'package:lotura/data/apply/dto/request/send_fcm_info_request.dart';
+import 'package:lotura/main.dart';
 
 abstract class ApplyEvent {}
 
@@ -11,13 +10,19 @@ class GetApplyListEvent extends ApplyEvent {
 }
 
 class ApplyCancelEvent extends ApplyEvent {
-  final ApplyCancelRequest applyCancelRequest;
+  final int deviceId;
 
-  ApplyCancelEvent({required this.applyCancelRequest});
+  ApplyCancelEvent({
+    required this.deviceId,
+  });
 }
 
 class SendFCMEvent extends ApplyEvent {
-  final SendFCMInfoRequest sendFCMInfoRequest;
+  final int deviceId;
+  final Machine deviceType;
 
-  SendFCMEvent({required this.sendFCMInfoRequest});
+  SendFCMEvent({
+    required this.deviceId,
+    required this.deviceType,
+  });
 }

--- a/lib/presentation/apply_page/ui/view/apply_page.dart
+++ b/lib/presentation/apply_page/ui/view/apply_page.dart
@@ -140,8 +140,8 @@ class ApplyPage extends StatelessWidget {
                                       MainAxisAlignment.spaceBetween,
                                   children: [
                                     MachineCard(
-                                        index: state.value.applyList[index * 2]
-                                            .deviceId,
+                                        deviceId: state.value
+                                            .applyList[index * 2].deviceId,
                                         isEnableNotification: false,
                                         isWoman: state
                                                     .value
@@ -155,7 +155,7 @@ class ApplyPage extends StatelessWidget {
                                         state: CurrentState.working),
                                     index * 2 + 1 < state.value.applyList.length
                                         ? MachineCard(
-                                            index: state
+                                            deviceId: state
                                                 .value
                                                 .applyList[index * 2 + 1]
                                                 .deviceId,

--- a/lib/presentation/laundry_room_page/ui/view/laundry_room_page.dart
+++ b/lib/presentation/laundry_room_page/ui/view/laundry_room_page.dart
@@ -255,18 +255,18 @@ class LaundryList extends StatelessWidget {
 
   MachineWidget machineWidget(
           {required LaundryRoomModel roomState,
-          required int index,
+          required int deviceId,
           required CurrentState state,
           required Machine machine}) =>
       roomState.buttonView == ButtonView.image
           ? MachineCard(
-              index: index,
+              deviceId: deviceId,
               isEnableNotification: true,
               isWoman: roomState.roomLocation == RoomLocation.womanRoom,
               state: state,
               machine: machine)
           : MachineButton(
-              index: index,
+              deviceId: deviceId,
               isEnableNotification: true,
               isWoman: roomState.roomLocation == RoomLocation.womanRoom,
               state: state,
@@ -290,7 +290,7 @@ class LaundryList extends StatelessWidget {
               ),
             ),
             builder: (context) => OSJBottomSheet(
-              index: nfcData,
+              deviceId: nfcData,
               isEnableNotification: true,
               isWoman: nfcData > 31 ? true : false,
               state: list[nfcData - 1].state,
@@ -313,7 +313,7 @@ class LaundryList extends StatelessWidget {
                 children: [
                   machineWidget(
                       roomState: laundryRoomModel,
-                      index: list[
+                      deviceId: list[
                               placeIndex[laundryRoomModel.roomLocation.index]! +
                                   index]
                           .id,
@@ -328,7 +328,7 @@ class LaundryList extends StatelessWidget {
                   laundryRoomModel.buttonView.triangle,
                   machineWidget(
                     roomState: laundryRoomModel,
-                    index: placeIndex[laundryRoomModel.roomLocation.index]! +
+                    deviceId: placeIndex[laundryRoomModel.roomLocation.index]! +
                                 index +
                                 (laundryRoomModel.roomLocation ==
                                         RoomLocation.womanRoom

--- a/lib/presentation/utils/machine_button.dart
+++ b/lib/presentation/utils/machine_button.dart
@@ -6,7 +6,7 @@ import 'package:lotura/presentation/utils/machine_widget.dart';
 class MachineButton extends MachineWidget {
   const MachineButton({
     super.key,
-    required super.index,
+    required super.deviceId,
     required super.isEnableNotification,
     required super.isWoman,
     required super.state,
@@ -37,10 +37,10 @@ class MachineButton extends MachineWidget {
                         size: 24.0.r, color: LoturaColors.gray300),
                     Row(
                       children: [
-                        Text("${isWoman ? index - 31 : index}번",
+                        Text("${isWoman ? deviceId - 31 : deviceId}번",
                             style: TextStyle(fontSize: 16.0.sp)),
                         SizedBox(
-                            width: (isWoman ? index - 31 : index) < 10
+                            width: (isWoman ? deviceId - 31 : deviceId) < 10
                                 ? 10.2.w
                                 : 5.0.w),
                         Text(machine.text, style: TextStyle(fontSize: 16.0.sp)),

--- a/lib/presentation/utils/machine_card.dart
+++ b/lib/presentation/utils/machine_card.dart
@@ -6,7 +6,7 @@ import 'package:lotura/presentation/utils/osj_status_button.dart';
 class MachineCard extends MachineWidget {
   const MachineCard({
     super.key,
-    required super.index,
+    required super.deviceId,
     required super.isEnableNotification,
     required super.isWoman,
     required super.machine,
@@ -41,7 +41,7 @@ class MachineCard extends MachineWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Text(
-                        "${isWoman ? index - 31 : index}번 ",
+                        "${isWoman ? deviceId - 31 : deviceId}번 ",
                         style: TextStyle(
                           fontSize: 16.0.sp,
                           fontWeight: FontWeight.w500,

--- a/lib/presentation/utils/machine_widget.dart
+++ b/lib/presentation/utils/machine_widget.dart
@@ -6,14 +6,14 @@ import 'package:lotura/presentation/utils/osj_bottom_sheet.dart';
 abstract class MachineWidget extends StatelessWidget {
   const MachineWidget({
     super.key,
-    required this.index,
+    required this.deviceId,
     required this.isEnableNotification,
     required this.isWoman,
     required this.state,
     required this.machine,
   });
 
-  final int index;
+  final int deviceId;
   final bool isEnableNotification, isWoman;
 
   final CurrentState state;
@@ -21,7 +21,7 @@ abstract class MachineWidget extends StatelessWidget {
   final Machine machine;
 
   bool get isEmptyContainer =>
-      (!isWoman && index == 32) || (isWoman && index == -1);
+      (!isWoman && deviceId == 32) || (isWoman && deviceId == -1);
 
   void showModalOSJBottomSheet({required BuildContext context}) =>
       showModalBottomSheet(
@@ -32,7 +32,7 @@ abstract class MachineWidget extends StatelessWidget {
           ),
         ),
         builder: (context) => OSJBottomSheet(
-          index: index,
+          deviceId: deviceId,
           isEnableNotification: isEnableNotification,
           isWoman: isWoman,
           state: state,

--- a/lib/presentation/utils/osj_bottom_sheet.dart
+++ b/lib/presentation/utils/osj_bottom_sheet.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:lotura/data/apply/dto/request/apply_cancel_request.dart';
-import 'package:lotura/data/apply/dto/request/send_fcm_info_request.dart';
 import 'package:lotura/main.dart';
 import 'package:lotura/presentation/apply_page/bloc/apply_bloc.dart';
 import 'package:lotura/presentation/apply_page/bloc/apply_event.dart';
@@ -14,14 +12,14 @@ import 'package:lotura/presentation/utils/osj_text_button.dart';
 class OSJBottomSheet extends StatefulWidget {
   const OSJBottomSheet({
     super.key,
-    required this.index,
+    required this.deviceId,
     required this.isEnableNotification,
     required this.isWoman,
     required this.state,
     required this.machine,
   });
 
-  final int index;
+  final int deviceId;
   final bool isEnableNotification, isWoman;
   final CurrentState state;
   final Machine machine;
@@ -36,31 +34,31 @@ class _OSJBottomSheetState extends State<OSJBottomSheet> {
       if (isWoman) {
         switch (state) {
           case CurrentState.working:
-            return "여자 세탁실 ${widget.index - 31}번 ${widget.machine.text}를\n알림 설정 하실건가요?";
+            return "여자 세탁실 ${widget.deviceId - 31}번 ${widget.machine.text}를\n알림 설정 하실건가요?";
           case CurrentState.available:
-            return "여자 세탁실 ${widget.index - 31}번 ${widget.machine.text}는\n현재 사용 가능한 상태에요.";
+            return "여자 세탁실 ${widget.deviceId - 31}번 ${widget.machine.text}는\n현재 사용 가능한 상태에요.";
           case CurrentState.disconnected:
-            return "여자층 ${widget.index - 31}번 ${widget.machine.text}의 연결이 끊겨서\n상태를 확인할 수 없어요.";
+            return "여자층 ${widget.deviceId - 31}번 ${widget.machine.text}의 연결이 끊겨서\n상태를 확인할 수 없어요.";
           case CurrentState.breakdown:
-            return "여자 세탁실 ${widget.index - 31}번 ${widget.machine.text}는\n고장으로 인해 사용이 불가능해요.";
+            return "여자 세탁실 ${widget.deviceId - 31}번 ${widget.machine.text}는\n고장으로 인해 사용이 불가능해요.";
         }
       } else {
         switch (state) {
           case CurrentState.working:
-            return "${widget.index}번 ${widget.machine.text}를\n알림 설정 하실건가요?";
+            return "${widget.deviceId}번 ${widget.machine.text}를\n알림 설정 하실건가요?";
           case CurrentState.available:
-            return "${widget.index}번 ${widget.machine.text}는\n현재 사용 가능한 상태에요.";
+            return "${widget.deviceId}번 ${widget.machine.text}는\n현재 사용 가능한 상태에요.";
           case CurrentState.disconnected:
-            return "${widget.index}번 ${widget.machine.text}의 연결이 끊겨서\n상태를 확인할 수 없어요.";
+            return "${widget.deviceId}번 ${widget.machine.text}의 연결이 끊겨서\n상태를 확인할 수 없어요.";
           case CurrentState.breakdown:
-            return "${widget.index}번 ${widget.machine.text}는\n고장으로 인해 사용이 불가능해요.";
+            return "${widget.deviceId}번 ${widget.machine.text}는\n고장으로 인해 사용이 불가능해요.";
         }
       }
     } else {
       if (isWoman) {
-        return "여자 세탁실 ${widget.index - 31}번 ${widget.machine.text}의\n알림 설정을 해제하실건가요?";
+        return "여자 세탁실 ${widget.deviceId - 31}번 ${widget.machine.text}의\n알림 설정을 해제하실건가요?";
       } else {
-        return "${widget.index}번 ${widget.machine.text}의\n알림 설정을 해제하실건가요?";
+        return "${widget.deviceId}번 ${widget.machine.text}의\n알림 설정을 해제하실건가요?";
       }
     }
   }
@@ -137,15 +135,13 @@ class _OSJBottomSheetState extends State<OSJBottomSheet> {
                             function: () {
                               widget.isEnableNotification
                                   ? context.read<ApplyBloc>().add(SendFCMEvent(
-                                      sendFCMInfoRequest: SendFCMInfoRequest(
-                                          deviceId: widget.index.toString(),
-                                          expectState: '1')))
-                                  : context.read<ApplyBloc>().add(
-                                      ApplyCancelEvent(
-                                          applyCancelRequest:
-                                              ApplyCancelRequest(
-                                                  deviceId: widget.index
-                                                      .toString())));
+                                      deviceId: widget.deviceId,
+                                      deviceType: widget.machine))
+                                  : context
+                                      .read<ApplyBloc>()
+                                      .add(ApplyCancelEvent(
+                                        deviceId: widget.deviceId,
+                                      ));
                               context
                                   .read<RoomBloc>()
                                   .add(ClosingBottomSheetEvent());


### PR DESCRIPTION
알림 신청하고 신청 리스트를 한번 더 받아오는 로직을 수정했습니다.
상태관리중인 리스트에 직접 추가함으로써 재요청을 삭제했고, 취소 시에도 똑같이 동작합니다.